### PR TITLE
feat: add static link to latest main build

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -39,6 +39,12 @@ const htmlSiteIndex = ({
   htmlPage(
     { title: `Storybooks for ${projectName} (${repo})` },
     html`
+      <h2>Latest static link</h2>
+      <ul>
+        <li>
+          <a href="commits/latest/index.html">Latest</a>
+        </li>
+      </ul>
       <h2>Latest ${mainBranch}</h2>
       <ul>
         ${commits

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -20,6 +20,17 @@ async function publishStorybooks(context) {
   const { commit } = commitMetadata;
   const publishBasePath = `commits/${commit}`;
 
+  await publishStorybook(context, publishBasePath, storybookBuilds);
+
+  if (commitMetadata.branch === config.github.mainBranch) {
+    await publishStorybook(context, 'commits/latest', storybookBuilds);
+  }
+}
+
+async function publishStorybook(context, publishBasePath, storybookBuilds) {
+  const { log, config, commitMetadata } = context;
+  const { commit } = commitMetadata;
+
   // Publish a JSON metadata resource for this batch of storybooks.
   // Note: This is not in the same "folder" as the rest, because
   // this `commits/metadata-` prefix is easier to search for later.


### PR DESCRIPTION
## Because:

* Need to provide a static URL to the latest Storybook builds from the
  main branch.

## This commit:

* When storybooks are built from a commit to the main branch also write
  the content to the static "latest" folder.
* Update the index page with a link to the static URL.

Closes #
* https://github.com/mozilla/fxa/issues/12697

## Additional Information

Update to homepage `index.html` with Latest static link. (Definitely open to suggestions on making this look better)
![image](https://user-images.githubusercontent.com/10620585/171722499-c5bc11ea-4067-441e-9309-8ac23cf7c2b1.png)

URL is static with link to `latest`
![image](https://user-images.githubusercontent.com/10620585/171723011-aab18366-24a7-4499-86a6-d1d291befb77.png)
